### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ If you're compiling for a Raspberry Pi, then the path to the required headers an
 ```
 cmake -DRPI_INCLUDE_DIR=/path/to/vc/include \
       -DRPI_LIB_DIR=/path/to/vc/lib \
+      -DRPI_BCM_HOST=1 \
+      -DRPI_VCHIQ_ARM=1 \
+      -DRPI_VCOS=1
       ..
 ```
 


### PR DESCRIPTION
Need to set -RPI_BCM_HOST=1 RPI_VCHIQ_ARM=1 RPI_VCOS=1.

```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
RPI_BCM_HOST
linked by target "cec" in directory /mnt/package/libcec-osmc/src/libcec-libcec-3.0.1/src/libcec
RPI_VCHIQ_ARM
linked by target "cec" in directory /mnt/package/libcec-osmc/src/libcec-libcec-3.0.1/src/libcec
RPI_VCOS
linked by target "cec" in directory /mnt/package/libcec-osmc/src/libcec-libcec-3.0.1/src/libcec
```
